### PR TITLE
Change to calculated time for the app to start polling.

### DIFF
--- a/custom_components/here_comes_the_bus/coordinator.py
+++ b/custom_components/here_comes_the_bus/coordinator.py
@@ -190,7 +190,16 @@ class HCBDataCoordinator(DataUpdateCoordinator):
         return HCBDataCoordinator.PM_ID
 
     def _get_start_time(self, stops: list[StudentStop]) -> time:
-        return min(stop.tier_start_time for stop in stops)
+        earliest = min(stop.start_time for stop in stops)
+        # Convert time to datetime to perform the addition
+        dummy_date = dt_util.now().date()  # Use any date, it doesn't matter for this
+        datetime_with_time = datetime.combine(dummy_date, earliest)
+
+        # Add 30 minutes
+        new_datetime = datetime_with_time - timedelta(minutes=30)
+
+        # Extract the time component from the new datetime
+        return new_datetime.time()
 
     def _get_end_time(self, stops: list[StudentStop]) -> time:
         latest = max(stop.start_time for stop in stops)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -299,7 +299,12 @@ def test_update_stops_am() -> None:
         ),
     ]
     coordinator._update_stops(student_data, stops)  # type: ignore This is magic mock
-    assert student_data.am_start_time == time(7, 0)
+    assert (
+        student_data.am_start_time
+        == (
+            datetime.combine(dt_util.now().date(), time(7, 15)) - timedelta(minutes=30)
+        ).time()
+    )
     assert (
         student_data.am_end_time
         == (
@@ -333,7 +338,12 @@ def test_update_stops_mid() -> None:
         ),
     ]
     coordinator._update_stops(student_data, stops)  # type: ignore This is magic mock
-    assert student_data.mid_start_time == time(12, 0)
+    assert (
+        student_data.mid_start_time
+        == (
+            datetime.combine(dt_util.now().date(), time(12, 15)) - timedelta(minutes=30)
+        ).time()
+    )
     assert (
         student_data.mid_end_time
         == (
@@ -367,7 +377,12 @@ def test_update_stops_pm() -> None:
         ),
     ]
     coordinator._update_stops(student_data, stops)  # type: ignore This is magic mock
-    assert student_data.pm_start_time == time(15, 0)
+    assert (
+        student_data.pm_start_time
+        == (
+            datetime.combine(dt_util.now().date(), time(15, 15)) - timedelta(minutes=30)
+        ).time()
+    )
     assert (
         student_data.pm_end_time
         == (


### PR DESCRIPTION
Tier Start Time is when the App and website are supposed to be able to see the bus.  Currently it is not coming back correctly.  This uses the scheduled time minus 30 minutes.

Closes #44 