### PR TITLE
Remove pip caching in lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version-file: ".python-version"
-          cache: "pip"
 
       - name: Install system libraries for lxml
         run: |


### PR DESCRIPTION
Removed pip caching from Python setup step in CI workflow.